### PR TITLE
feat: add jsonata transformer layer

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { TraceOrchestrator } from './orchestrator.js';
 export { VisualizerRegistry } from './visualizer-registry.js';
 export { JSONataVersionDetector } from './version-detector.js';
+export { JSONataTransformer } from './transformer.js';
 
 export type {
   Version,
@@ -15,6 +16,7 @@ export type {
 } from './types.js';
 
 export type { JSONataVersionDetectorConfig } from './version-detector.js';
+export type { JSONataTransformerConfig } from './transformer.js';
 
 // Re-export schema utilities for convenience
 export * from './schemas/index.js';

--- a/packages/core/src/transformer.ts
+++ b/packages/core/src/transformer.ts
@@ -1,0 +1,54 @@
+import jsonata from 'jsonata';
+import type { RawTrace, Transformer, Version } from './types.js';
+
+export interface JSONataTransformerConfig {
+  /**
+   * JSONata expression that transforms the trace into the desired structure.
+   */
+  expression: string;
+
+  /**
+   * Optional list of versions that this transformer supports. When omitted the
+   * expression will be applied to any version.
+   */
+  versions?: Array<Version>;
+}
+
+export class JSONataTransformer implements Transformer {
+  private expression: jsonata.Expression;
+  private versions?: Set<Version>;
+
+  constructor(private config: JSONataTransformerConfig) {
+    try {
+      this.expression = jsonata(config.expression);
+    } catch (error) {
+      throw new Error(
+        `Invalid JSONata expression: ${config.expression}. ` +
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (config.versions && config.versions.length > 0) {
+      this.versions = new Set(config.versions);
+    }
+  }
+
+  canTransform(fromVersion: Version): boolean {
+    if (!this.versions) {
+      return true;
+    }
+
+    return this.versions.has(fromVersion);
+  }
+
+  async transform(trace: RawTrace): Promise<unknown> {
+    try {
+      return await this.expression.evaluate(trace);
+    } catch (error) {
+      throw new Error(
+        `JSONata transformation failed for expression "${this.config.expression}": ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a JSONata-based transformer that can optionally target specific versions
- export the transformer and configuration types from the core entrypoint

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e1ab381f648326a85d90fb74ab8015