### PR TITLE
chore: enforce squash-only merges

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,19 @@
+repository:
+  allow_merge_commit: false
+  allow_rebase_merge: false
+  allow_squash_merge: true
+  squash_merge_commit_title: PR_TITLE
+  delete_branch_on_merge: true
+  default_branch: main
+
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - CI
+      enforce_admins: false
+      required_linear_history: false
+      required_pull_request_reviews: null
+      restrictions: null


### PR DESCRIPTION
## Summary
- configure repository settings so the main branch requires the CI workflow to pass before merging
- restrict merging strategy to squash merges that use the PR title

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68e1ad764c94832695f01a923a58cf47