### PR TITLE
refactor: replace Transformer with TracePreparer

### DIFF
--- a/examples/basic-react/src/App.tsx
+++ b/examples/basic-react/src/App.tsx
@@ -1,7 +1,26 @@
-import { JSONataVersionDetector, useTrace } from '@trace-viz/react';
+import { TraceV1Schema, TraceV2Schema } from '@trace-viz/core';
+import {
+  JSONataVersionDetector,
+  useTrace,
+  type TracePreparer,
+  type TraceV1,
+  type TraceV2,
+} from '@trace-viz/react';
 import { useState } from 'react';
 import { TraceViewerV1 } from './visualizers/TraceViewerV1';
 import { TraceViewerV2 } from './visualizers/TraceViewerV2';
+
+const preparer: TracePreparer<TraceV1 | TraceV2> = {
+  prepare(trace, { version }) {
+    if (version === '1') {
+      return TraceV1Schema.parse(trace);
+    }
+    if (version === '2') {
+      return TraceV2Schema.parse(trace);
+    }
+    return trace as TraceV1 | TraceV2;
+  },
+};
 
 // Sample trace data
 const sampleTraceV1 = {
@@ -62,7 +81,8 @@ export function App() {
     trace,
     version,
     visualizer: Visualizer,
-  } = useTrace({
+  } = useTrace<TraceV1 | TraceV2>({
+    preparer,
     versionDetector: new JSONataVersionDetector({
       expression: 'version',
       fallback: '1',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ export type {
   VisualizerComponent,
   StateSubscriber,
   VersionDetector,
-  Transformer,
+  TracePreparer,
   OrchestratorConfig,
 } from './types.js';
 

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -79,24 +79,22 @@ export class TraceOrchestrator<T = unknown> {
       // Detect version
       const version = this.config.versionDetector.detect(rawTrace);
 
-      // Transform if needed
-      let processedTrace: unknown = rawTrace;
-      if (this.config.autoTransform && this.config.transformer) {
-        if (this.config.transformer.canTransform(version)) {
-          processedTrace = await this.config.transformer.transform(
-            rawTrace,
-            version,
-          );
-        }
-      }
-
       // Get visualizer
       const visualizer = this.registry.get(version);
+
+      // Prepare trace for visualization
+      let preparedTrace: unknown = rawTrace;
+      if (this.config.preparer) {
+        preparedTrace = await this.config.preparer.prepare(rawTrace, {
+          version,
+          visualizer,
+        });
+      }
 
       this.updateState({
         error: null,
         status: 'success',
-        trace: processedTrace as T,
+        trace: preparedTrace as T,
         version,
         visualizer,
       });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -34,27 +34,23 @@ export interface VersionDetector {
 }
 
 /**
- * Transformer interface for converting between versions
+ * Preparer interface for transforming raw trace into visualization-ready format
  */
-export interface Transformer {
-  canTransform(fromVersion: Version): boolean;
-  transform(trace: RawTrace, fromVersion: Version): Promise<unknown> | unknown;
+export interface TracePreparer<T = unknown> {
+  prepare(
+    trace: RawTrace,
+    ctx: { version: Version; visualizer?: VisualizerComponent | string },
+  ): Promise<T> | T;
 }
 
 /**
  * Orchestrator configuration
  */
-export interface OrchestratorConfig {
+export interface OrchestratorConfig<T = unknown> {
   /**
-   * Whether to automatically transform to latest version
-   * Default: false (keep original version)
+   * Optional preparer for transforming trace data for visualization
    */
-  autoTransform?: boolean;
-
-  /**
-   * Optional transformer for migrating between versions
-   */
-  transformer?: Transformer;
+  preparer?: TracePreparer<T>;
 
   /**
    * Version detector to extract version from raw trace

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,7 +10,7 @@ export type {
   OrchestratorState,
   VisualizerComponent,
   VersionDetector,
-  Transformer,
+  TracePreparer,
   OrchestratorConfig,
   TraceV1,
   TraceV2,

--- a/packages/react/src/use-trace.ts
+++ b/packages/react/src/use-trace.ts
@@ -6,14 +6,14 @@ import {
 } from '@trace-viz/core';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-export interface UseTraceOptions extends OrchestratorConfig {
+export interface UseTraceOptions<T = unknown> extends OrchestratorConfig<T> {
   /**
    * Initial trace to process on mount
    */
   initialTrace?: RawTrace;
 }
 
-export function useTrace<T = unknown>(options: UseTraceOptions) {
+export function useTrace<T = unknown>(options: UseTraceOptions<T>) {
   const { initialTrace, ...config } = options;
 
   const orchestrator = useMemo(


### PR DESCRIPTION
## Summary

Refactored the `Transformer` interface to `TracePreparer` to better reflect its purpose of preparing trace data for visualization rather than migrating between versions.

## Changes

### Core Package
- ✅ Replaced `Transformer` interface with `TracePreparer`
- ✅ Changed from `canTransform(version)` + `transform(trace, version)` to single `prepare(trace, ctx)` method
- ✅ Removed `autoTransform` config option
- ✅ Updated orchestrator logic: detect version → get visualizer → prepare trace → render
- ✅ Updated exports in `packages/core/src/index.ts`

### React Package
- ✅ Made `UseTraceOptions` generic for better type inference
- ✅ Updated exports to use `TracePreparer` instead of `Transformer`

### Example
- ✅ Added preparer implementation using Zod schemas for validation
- ✅ Demonstrates new API with typed preparer

## Rationale

The transformer was incorrectly positioned as a version migration tool, when its actual purpose is to transform raw trace data into a visualization-ready format (extracting subsets, computing derived fields, etc.).

The new `TracePreparer` interface:
- Has a clearer, single responsibility
- Receives both version and visualizer context for flexible preparation
- Simplifies the orchestration pipeline
- Improves type safety with generics

## Testing

- ✅ All typechecks pass
- ✅ All builds pass
- ✅ All linting and formatting pass
- ✅ Example application updated and builds successfully