### PR TITLE
chore: update dependencies and TypeScript config

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "jsonata": "^2.0.3",
-    "zod": "^3.22.4"
+    "zod": "^4.1.0"
   },
   "devDependencies": {
     "tsdown": "^0.15.6",

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 // Common span structure
 export const SpanBase = z.object({
-  attributes: z.record(z.unknown()).optional(),
+  attributes: z.record(z.string(), z.unknown()).optional(),
   endTime: z.number(),
   name: z.string(),
   parentId: z.string().optional(),
@@ -36,7 +36,7 @@ export const SpanV2 = SpanBase.extend({
 });
 
 export const TraceV2Schema = z.object({
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   spans: z.array(SpanV2),
   timestamp: z.number(),
   traceId: z.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^2.0.3
         version: 2.1.0
       zod:
-        specifier: ^3.22.4
-        version: 3.25.76
+        specifier: ^4.1.0
+        version: 4.1.11
     devDependencies:
       tsdown:
         specifier: ^0.15.6
@@ -2924,8 +2924,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
 snapshots:
 
@@ -4371,8 +4371,8 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/parser': 7.28.4
       eslint: 9.37.0(jiti@2.6.1)
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.1.11
+      zod-validation-error: 4.0.2(zod@4.1.11)
     transitivePeerDependencies:
       - supports-color
 
@@ -5904,8 +5904,8 @@ snapshots:
 
   yocto-queue@1.2.1: {}
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.1.11):
     dependencies:
-      zod: 3.25.76
+      zod: 4.1.11
 
-  zod@3.25.76: {}
+  zod@4.1.11: {}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "allowJs": true,
     "checkJs": false,


### PR DESCRIPTION
## Summary

Updates Zod dependency and improves TypeScript configuration for stricter type checking.

## Changes

### Dependencies
- ✅ Upgrade `zod` from `^3.22.4` to `^4.1.0`

### Schema Fixes
- ✅ Fixed Zod schema type errors by adding explicit string key types to `z.record()`
  - `z.record(z.unknown())` → `z.record(z.string(), z.unknown())`
  - Applied to `attributes` field in `SpanBase`
  - Applied to `metadata` field in `TraceV2Schema`

### TypeScript Config
- ✅ Enabled `verbatimModuleSyntax` in `tsconfig.base.json` for stricter module handling
  - Ensures import/export statements are preserved exactly as written
  - Prevents accidental type-only imports from being removed

## Testing

- ✅ All typechecks pass
- ✅ All linting passes
- ✅ All formatting checks pass
- ✅ All tests pass