### PR TITLE
fix(ci): fix build order and upgrade to actions v5 with Node 20.19+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: ['20.19', '22']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

Fixes failing dependabot PR builds and prepares CI for upcoming Vite 7 and React 19 upgrades.

## Changes

### Build Order Fix
- Move build step before typecheck/lint to ensure type declarations are available
- Fixes issue where @trace-viz/react couldn't find @trace-viz/core types

### GitHub Actions Upgrades  
- Upgrade actions/checkout from v4 to v5
- Upgrade actions/setup-node from v4 to v5
- Pin Node 20 to 20.19 minimum (required by Vite 7 and @vitejs/plugin-react v5)

## Testing

- [x] Pre-commit hooks pass
- [x] CI will validate on this PR

## Related

Fixes failing builds on PRs #7-#13