### PR TITLE
docs: add git workflow guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,12 @@
   - Run `pnpm format` to ensure proper formatting (Prettier adds blank lines between Mermaid code blocks)
   - Keep architecture diagrams and documentation in sync with code changes
   - Update usage examples if APIs change
+
+## Git Workflow
+
+- **NEVER commit directly to main**: Always use feature branches
+  1. Create a branch: `git checkout -b <branch-name>`
+  2. Make changes and commit
+  3. Push the branch: `git push -u origin <branch-name>` or use GitHub MCP
+  4. Create a PR using GitHub MCP tools
+- **Branch naming**: Use conventional format (feat/, fix/, chore/, docs/, etc.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,6 @@
 - **NEVER commit directly to main**: Always use feature branches
   1. Create a branch: `git checkout -b <branch-name>`
   2. Make changes and commit
-  3. Push the branch: `git push -u origin <branch-name>` or use GitHub MCP
+  3. Push the branch using GitHub MCP
   4. Create a PR using GitHub MCP tools
 - **Branch naming**: Use conventional format (feat/, fix/, chore/, docs/, etc.)


### PR DESCRIPTION
Adds Git Workflow section to AGENTS.md to remind agents to:
- NEVER commit directly to main
- Always use feature branches
- Follow proper branch naming conventions (feat/, fix/, chore/, docs/, etc.)
- Create PRs using GitHub MCP tools

This also includes the fix from the previous commit that adds a build step to the Release workflow to ensure packages are built before the pre-push typecheck runs.