### PR TITLE
feat: implement oracle-recommended API improvements

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,7 +44,8 @@ orchestrator.registerVisualizer({ version: '2', component: TraceViewerV2 });
 orchestrator.setDefaultVisualizer({ component: DefaultViewer });
 
 // Process trace data
-await orchestrator.process({ rawTrace: traceData });
+const state = await orchestrator.process({ rawTrace: traceData });
+console.log(state.status); // "success"
 
 // Subscribe to state changes
 const unsubscribe = orchestrator.subscribe((state) => {
@@ -113,18 +114,25 @@ Constructor options:
 
 Methods:
 
-- `process(options)`: Process trace data
+- `process(options)`: Process trace data and return the updated orchestrator state
   - `rawTrace`: Trace data to process (required)
   - `overrideVersion`: Optional version to use instead of detection
   - `visualizer`: Optional visualizer component to use instead of registry lookup
 - `registerVisualizer(options)`: Register visualizer for version
   - `version`: Version string (required)
   - `component`: Visualizer component (required)
-- `registerVisualizers(mapping)`: Register multiple visualizers
+- `replace`: Optional flag (defaults to `true`). When `false`, attempting to register an existing version will throw.
+- `registerVisualizerBatch(entries)`: Register an array of visualizer configurations
+- `registerVisualizers(mapping)`: Register multiple visualizers from a record map
 - `setDefaultVisualizer(options)`: Set fallback visualizer
   - `component`: Visualizer component (required)
+- `getRegisteredVersions()`: List of explicitly registered versions
+- `getVisualizer(version)`: Resolve the visualizer that would be used for a version
+- `hasVisualizer(version)`: Check if a visualizer (or default) is available for a version
+- `getDefaultVisualizer()`: Retrieve the configured default visualizer, if any
 - `subscribe(callback)`: Subscribe to state changes
 - `reset()`: Reset to initial state
+- `clearVisualizers()`: Remove all registered and default visualizers
 
 ### `JSONataVersionDetector`
 
@@ -132,6 +140,7 @@ Constructor options:
 
 - `expression`: JSONata expression to extract version
 - `fallback`: Optional fallback version string
+- `onError`: Optional callback invoked when detection fails but a fallback is returned
 
 ## Development
 

--- a/packages/core/src/__tests__/orchestrator.test.ts
+++ b/packages/core/src/__tests__/orchestrator.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TraceOrchestrator } from '../orchestrator.js';
+import type { RawTrace, VisualizerComponent } from '../types.js';
+import { JSONataVersionDetector } from '../version-detector.js';
+import { VisualizerRegistry } from '../visualizer-registry.js';
+
+const mockComponent: VisualizerComponent = () => null;
+const mockVisualizer: VisualizerComponent = () => null;
+
+describe('VisualizerRegistry', () => {
+  it('respects the replace flag when registering visualizers', () => {
+    const registry = new VisualizerRegistry();
+
+    registry.register({ component: mockComponent, version: '1' });
+
+    expect(() =>
+      registry.register({
+        component: mockComponent,
+        replace: false,
+        version: '1',
+      }),
+    ).toThrowError(/already registered/);
+  });
+});
+
+describe('TraceOrchestrator', () => {
+  it('returns the latest state from process and preserves last success on failure', async () => {
+    const orchestrator = new TraceOrchestrator<RawTrace>({
+      preparer: {
+        prepare: (trace: RawTrace) => {
+          if ((trace as Record<string, unknown>).fail) {
+            throw new Error('preparer failed');
+          }
+          return { ...trace, prepared: true };
+        },
+      },
+      versionDetector: {
+        detect: vi.fn(async () => '1'),
+      },
+    });
+    orchestrator.registerVisualizer({
+      component: mockVisualizer,
+      version: '1',
+    });
+
+    const successState = await orchestrator.process({ rawTrace: { id: 1 } });
+    expect(successState.status).toBe('success');
+    expect(successState.trace).toEqual({ id: 1, prepared: true });
+    expect(successState.visualizer).toBe(mockVisualizer);
+
+    const errorState = await orchestrator.process({
+      rawTrace: { fail: true },
+    });
+    expect(errorState.status).toBe('error');
+    expect(errorState.error?.message).toContain('preparer failed');
+    expect(errorState.trace).toEqual(successState.trace);
+    expect(errorState.visualizer).toBe(successState.visualizer);
+
+    expect(orchestrator.getRegisteredVersions()).toEqual(['1']);
+    expect(orchestrator.hasVisualizer('1')).toBe(true);
+    expect(orchestrator.hasVisualizer('2')).toBe(false);
+    expect(orchestrator.getVisualizer('1')).toBe(mockVisualizer);
+
+    orchestrator.setDefaultVisualizer({ component: mockVisualizer });
+    expect(orchestrator.getDefaultVisualizer()).toBe(mockVisualizer);
+    expect(orchestrator.hasVisualizer('2')).toBe(true);
+  });
+});
+
+describe('JSONataVersionDetector', () => {
+  it('invokes onError when evaluation returns nullish but fallback is used', async () => {
+    const onError = vi.fn();
+    const detector = new JSONataVersionDetector({
+      expression: 'metadata.version',
+      fallback: '1',
+      onError,
+    });
+
+    const version = await detector.detect({ metadata: {} });
+    expect(version).toBe('1');
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    const [error, context] = onError.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect(context.expression).toBe('metadata.version');
+    expect(context.fallback).toBe('1');
+    expect(context.result).toBeUndefined();
+    expect(context.trace).toEqual({ metadata: {} });
+  });
+
+  it('invokes onError when evaluation throws but fallback is configured', async () => {
+    const onError = vi.fn();
+    const detector = new JSONataVersionDetector({
+      expression: 'error("unexpected")',
+      fallback: '1',
+      onError,
+    });
+
+    const version = await detector.detect({});
+    expect(version).toBe('1');
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    const [error, context] = onError.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBeTruthy();
+    expect(context.expression).toBe('error("unexpected")');
+    expect(context.fallback).toBe('1');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,10 @@ export type {
   VisualizerComponent,
 } from './types.js';
 
-export type { JSONataVersionDetectorConfig } from './version-detector.js';
+export type {
+  JSONataVersionDetectorConfig,
+  JSONataVersionDetectorErrorContext,
+} from './version-detector.js';
 
 // Re-export schema utilities for convenience
 export * from './schemas/index.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,6 +37,18 @@ export interface VersionDetector {
  * Preparer interface for transforming raw trace into visualization-ready format
  */
 export interface TracePreparer<T = unknown> {
+  /**
+   * Optional callback invoked when preparation fails.
+   * Useful for logging or debugging preparation errors.
+   */
+  onError?: (
+    error: Error,
+    context: {
+      trace: RawTrace;
+      version: Version;
+      visualizer?: VisualizerComponent | string;
+    },
+  ) => void;
   prepare(
     trace: RawTrace,
     ctx: { version: Version; visualizer?: VisualizerComponent | string },
@@ -80,7 +92,8 @@ export interface RegisterVisualizerOptions {
   component: VisualizerComponent;
   /**
    * Whether to replace existing visualizer for the same version if present.
-   * Default behavior is to replace (to match current semantics).
+   * Defaults to `true`. When set to `false`, attempting to register a version
+   * that already exists will throw.
    */
   replace?: boolean;
   version: Version;

--- a/packages/core/src/visualizer-registry.ts
+++ b/packages/core/src/visualizer-registry.ts
@@ -13,9 +13,15 @@ export class VisualizerRegistry {
    * Register a visualizer for a specific version
    */
   register(options: RegisterVisualizerOptions): this {
-    const { component, version } = options;
-    // Current behavior is to replace; we keep this as-is regardless of `replace`
-    // but we keep the flag for future use (e.g., throw on duplicates when replace === false).
+    const { component, replace = true, version } = options;
+
+    const hasExactMatch = this.visualizers.has(version);
+    if (hasExactMatch && replace === false) {
+      throw new Error(
+        `Visualizer for version "${version}" already registered. Pass "replace: true" to overwrite.`,
+      );
+    }
+
     this.visualizers.set(version, component);
     return this;
   }
@@ -81,7 +87,21 @@ export class VisualizerRegistry {
    * Get all registered versions
    */
   getVersions(): Array<Version> {
+    return this.getRegisteredVersions();
+  }
+
+  /**
+   * Get all registered versions (exact keys only)
+   */
+  getRegisteredVersions(): Array<Version> {
     return Array.from(this.visualizers.keys());
+  }
+
+  /**
+   * Get the configured default visualizer, if any.
+   */
+  getDefaultVisualizer(): VisualizerComponent | undefined {
+    return this.defaultVisualizer;
   }
 
   private trySemanticMatch(version: Version): VisualizerComponent | null {


### PR DESCRIPTION
## Summary

Implements critical API improvements based on oracle code review recommendations to fix race conditions, improve error handling, and enhance API ergonomics.

## Changes

### Core Package (`@trace-viz/core`)

- ✅ **onError callback for TracePreparer**: Added optional `onError` callback to `TracePreparer` interface for better error observability
- ✅ **Orchestrator error handling**: Wrapped preparer calls to invoke `onError` callback when preparation fails
- ✅ **Type consistency**: Fixed `hasVisualizer` to use `Version` type instead of `string`
- ✅ **Comprehensive tests**: Added tests for registry `replace` flag, state preservation on errors, and `onError` callbacks

### React Package (`@trace-viz/react`)

- ✅ **Fixed effect ordering race**: Combined registry configuration and `initialTrace` processing into a single effect to prevent race conditions where trace processing happens before visualizers are registered
- ✅ **Declarative idempotency**: Declarative visualizers now automatically use `replace: true` for idempotent behavior
- ✅ **Type safety**: Added `Version` import and fixed `hasVisualizer` signature

### Example App

- ✅ **Custom trace error handling**: Added user-facing error messages for invalid JSON and empty traces
- ✅ **Restore defaults button**: Added UI control to restore visualizers after clearing registry

## Testing

- All tests pass (lint, typecheck, unit tests, formatting)
- New test coverage for registry replacement, error state preservation, and onError callbacks
- Pre-push hooks passed successfully

## Breaking Changes

None - all changes are backward compatible additions and fixes.